### PR TITLE
Add dynamic questionnaire

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,12 @@
         <br>
         <button type="submit">Enviar</button>
     </form>
+
+    <h2>Cuestionario</h2>
+    <form id="cuestionario">
+        <!-- Las preguntas se generan dinámicamente -->
+        <button type="submit">Guardar respuestas</button>
+    </form>
     <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -2,3 +2,52 @@ document.getElementById('datos-personales').addEventListener('submit', function(
     event.preventDefault();
     alert('Formulario enviado');
 });
+
+// Preguntas del cuestionario (valor 1 si se marca "Verdadero", 0 si es "Falso")
+const preguntas = [
+    'Últimamente parece que me quedo sin fuerzas, incluso por la mañana',
+    'Me parece muy bien que haya normas porque son una buena guía a seguir',
+    'Disfruto haciendo tantas cosas diferentes que no puedo decidir por cuál empezar',
+    'Gran parte del tiempo me siento débil y cansado',
+    'Sé que soy superior a los demás, por eso no me importa lo que piense la gente'
+];
+
+const cuestionario = document.getElementById('cuestionario');
+
+preguntas.forEach((texto, index) => {
+    const fieldset = document.createElement('fieldset');
+    const legend = document.createElement('legend');
+    legend.textContent = texto;
+    fieldset.appendChild(legend);
+
+    const labelV = document.createElement('label');
+    const radioV = document.createElement('input');
+    radioV.type = 'radio';
+    radioV.name = 'p' + index;
+    radioV.value = '1';
+    labelV.appendChild(radioV);
+    labelV.append(' Verdadero');
+
+    const labelF = document.createElement('label');
+    const radioF = document.createElement('input');
+    radioF.type = 'radio';
+    radioF.name = 'p' + index;
+    radioF.value = '0';
+    labelF.appendChild(radioF);
+    labelF.append(' Falso');
+
+    fieldset.appendChild(labelV);
+    fieldset.appendChild(labelF);
+    cuestionario.insertBefore(fieldset, cuestionario.firstChild);
+});
+
+cuestionario.addEventListener('submit', function(event) {
+    event.preventDefault();
+    const respuestas = {};
+    preguntas.forEach((_, index) => {
+        const seleccion = cuestionario.querySelector('input[name="p' + index + '"]:checked');
+        respuestas['p' + index] = seleccion ? seleccion.value : null;
+    });
+    console.log(respuestas);
+    alert('Respuestas guardadas');
+});


### PR DESCRIPTION
## Summary
- add a new questionnaire section on the web page
- generate questionnaire items dynamically in JavaScript

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844db8ef6dc8328a865b24e6179a9c7