### PR TITLE
Add numbered two-column questionnaire layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,7 +187,7 @@ const cuestionario = document.getElementById('cuestionario');
 preguntas.forEach((texto, index) => {
     const fieldset = document.createElement('fieldset');
     const legend = document.createElement('legend');
-    legend.textContent = texto;
+    legend.textContent = (index + 1) + '. ' + texto;
     fieldset.appendChild(legend);
 
     const labelV = document.createElement('label');

--- a/style.css
+++ b/style.css
@@ -3,8 +3,19 @@ body {
     margin: 20px;
 }
 
-form {
+#datos-personales {
     max-width: 400px;
+}
+
+#cuestionario {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+#cuestionario fieldset {
+    width: calc(50% - 10px);
+    box-sizing: border-box;
 }
 
 fieldset {


### PR DESCRIPTION
## Summary
- enumerate questionnaire items in `main.js`
- style `cuestionario` form to display in two columns via `style.css`
- keep personal data form width fixed

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6844de9210fc8328b9d3caf801a909b0