### PR TITLE
Set default answers to Verdadero

### DIFF
--- a/main.js
+++ b/main.js
@@ -195,6 +195,7 @@ preguntas.forEach((texto, index) => {
     radioV.type = 'radio';
     radioV.name = 'p' + index;
     radioV.value = '1';
+    radioV.checked = true;
     labelV.appendChild(radioV);
     labelV.append(' Verdadero');
 


### PR DESCRIPTION
## Summary
- mark each questionnaire option as `Verdadero` by default

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6844f88c78c08328950eb040cb219c91