### PR TITLE
Add Word report export

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
         <div><span class="color valido"></span> Válido</div>
         <div><span class="color invalido"></span> Inválido</div>
     </div>
+    <button id="descargar-informe">Descargar informe en Word</button>
     <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a button to download a Word report
- store personal information when the form is submitted
- compute results once and keep them for generating the report
- include helper functions and generate Word file with available data

## Testing
- `python3 -m py_compile sinceridad.py`

------
https://chatgpt.com/codex/tasks/task_e_6845dff12bdc8328b855ed7a197f4283