### PR TITLE
Add chart info legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,49 @@
     </div>
     <h2>Perfil MCMI-III</h2>
     <canvas id="mcmiChart" height="900"></canvas>
+    <div id="chart-info">
+        <p><b>Bruto</b> y <b>BR</b> se refieren a la cifra obtenida.</p>
+        <p><b>Patrones cl&iacute;nicos de personalidad</b></p>
+        <div class="amber-light"><ul>
+            <li>1 Esquizoide: Bruto y BR</li>
+            <li>2A Evitativo: Bruto y BR</li>
+            <li>2B Depresivo: Bruto y BR</li>
+            <li>3 Dependiente: Bruto y BR</li>
+            <li>4 Histri&oacute;nico: Bruto y BR</li>
+            <li>5 Narcisita: Bruto y BR</li>
+            <li>6A Antisocial: Bruto y BR</li>
+            <li>6B Agresivo-s&aacute;dico: Bruto y BR</li>
+            <li>7 Compulsivo: Bruto y BR</li>
+            <li>8A Negativista (pasivo-agresivo): Bruto y BR</li>
+            <li>8B Autodestructiva: Bruto y BR</li>
+        </ul></div>
+        <div class="amber"><ul>
+            <li>S Esquizot&iacute;pica: Bruto y BR</li>
+            <li>C L&iacute;mite: Bruto y BR</li>
+            <li>P Paranoide: Bruto y BR</li>
+        </ul></div>
+        <div class="amber-light"><ul>
+            <li>A Trastornos de Ansiedad: Bruto y BR</li>
+            <li>H Trastorno Somatoformo: Bruto y BR</li>
+            <li>N Trastorno Bipolar: Bruto y BR</li>
+            <li>D Trastorno Dist&iacute;mico: Bruto y BR</li>
+            <li>B Dependencia del alcohol: Bruto y BR</li>
+            <li>T Dependencia de sustancias: Bruto y BR</li>
+            <li>R Trastorno estr&eacute;s postraum&aacute;tico: Bruto y BR</li>
+        </ul></div>
+        <div class="amber"><ul>
+            <li>SS Desorden del pensamiento: Bruto y BR</li>
+            <li>CC Depresi&oacute;n mayor: Bruto y BR</li>
+            <li>PP Desorden delusional: Bruto y BR</li>
+        </ul></div>
+        <p><b>Escalas Modificadores</b></p>
+        <div class="amber"><ul>
+            <li>X Sinceridad: Bruto y BR</li>
+            <li>Y Deseabilidad Social: Bruto y BR</li>
+            <li>Z Devaluaci&oacute;n: Bruto y BR</li>
+            <li>V Validez: Bruto y BR</li>
+        </ul></div>
+    </div>
     <button id="descargar-informe">Descargar informe en Word</button>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="main.js"></script>

--- a/style.css
+++ b/style.css
@@ -85,3 +85,11 @@ canvas {
     margin: auto;
     display: block;
 }
+/* info styles */
+#chart-info {
+    max-width: 600px;
+    margin-top: 10px;
+}
+.amber-light { background-color: #fef3c7; padding: 5px; }
+.amber { background-color: #fde68a; padding: 5px; }
+#chart-info ul { margin: 0; padding-left: 20px; }


### PR DESCRIPTION
## Summary
- add explanatory legend next to profile chart
- style the new legend blocks

## Testing
- `python3 -m py_compile sinceridad.py`

------
https://chatgpt.com/codex/tasks/task_e_68461ca79eb083288ed228a992951cc5