### PR TITLE
Show raw scores in MCMI‑III report

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Este repositorio contiene un ejemplo de cuestionario web y utilidades adicionales.
 
+Al completar el cuestionario es posible descargar un informe en formato Word. Dicho
+informe ahora muestra para cada escala del MCMI‑III tanto el puntaje bruto
+como su correspondiente índice BR.
+
 ## Calcular Índice de Sinceridad
 
 Se incluye un script `sinceridad.py` para obtener un BR aproximado de la escala X (Sinceridad) del MCMI‑III.

--- a/main.js
+++ b/main.js
@@ -760,9 +760,10 @@ function generarInforme() {
     const baremo = sexo === "F" ? "Femenino" : (sexo === "M" ? "Masculino" : "");
 
     function infoBR(clave) {
-        const br = obtenerBR(sexo || generoSeleccionado, codeMap[clave], lastResults[clave] || 0);
+        const bruto = lastResults[clave] || 0;
+        const br = obtenerBR(sexo || generoSeleccionado, codeMap[clave], bruto);
         const clas = obtenerClasificacion(br).texto;
-        return { br, clas };
+        return { bruto, br, clas };
     }
 
     const x = infoBR('sinceridad');
@@ -774,14 +775,14 @@ function generarInforme() {
     const tpKeys = ['esquizotipica','limite','paranoide'];
     const tpHtml = tpKeys.map(k => {
         const inf = infoBR(k);
-        return `<li>${detallesPatrones[k].nombre}: ${inf.br} (${inf.clas})</li>`;
+        return `<li>${detallesPatrones[k].nombre}: Br ${inf.bruto}, BR ${inf.br} (${inf.clas})</li>`;
     }).join('');
 
     const scSevero = ['pensamiento','depresion','delusional'];
     const scSeveroHtml = scSevero.map(k => {
         const nombres = {pensamiento:'SS Desorden del pensamiento', depresion:'CC Depresión mayor', delusional:'PP Desorden delusional'};
         const inf = infoBR(k);
-        return `<li>${nombres[k]}: ${inf.br} (${inf.clas})</li>`;
+        return `<li>${nombres[k]}: Br ${inf.bruto}, BR ${inf.br} (${inf.clas})</li>`;
     }).join('');
 
     const maxGlobal = Math.max(
@@ -804,7 +805,7 @@ function generarInforme() {
                 k === 'depresion' ? 'CC Depresión mayor' :
                 k === 'delusional' ? 'PP Desorden delusional' :
                 (k.charAt(0).toUpperCase() + k.slice(1)));
-            escalaDestacable.push(`<li>${nombreEsc}: ${inf.br} (${inf.clas})</li>`);
+            escalaDestacable.push(`<li>${nombreEsc}: Br ${inf.bruto}, BR ${inf.br} (${inf.clas})</li>`);
         }
     });
     const escalaDestacableHtml = escalaDestacable.join('');
@@ -814,7 +815,7 @@ function generarInforme() {
         const inf = infoBR(k);
         if (inf.br < 60) return '';
         const d = detallesPatrones[k];
-        return `<p><b>${d.nombre}:</b> ${inf.br} (${inf.clas})<br>
+        return `<p><b>${d.nombre}:</b> Br ${inf.bruto}, BR ${inf.br} (${inf.clas})<br>
         Comportamiento observable: ${d.observable}. Comportamiento interpersonal: ${d.interpersonal}. Estilo cognitivo: ${d.estilo}. Autoimagen: ${d.autoimagen}. Representaciones objetales: ${d.objetales}. Mecanismos de defensa: ${d.defensa}. Organización morfológica: ${d.morfologia}. Estado de ánimo / temperamento: ${d.animo}.</p>`;
     }).join('');
 
@@ -831,7 +832,7 @@ function generarInforme() {
     const sindHtml = sindromes.map(k => {
         const inf = infoBR(k);
         if (inf.br < 60) return '';
-        return `<li>${nombresSind[k]}: ${inf.br} (${inf.clas})</li>`;
+        return `<li>${nombresSind[k]}: Br ${inf.bruto}, BR ${inf.br} (${inf.clas})</li>`;
     }).join('');
 
     const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>
@@ -846,10 +847,10 @@ function generarInforme() {
 <h2>2 Actitud ante la prueba</h2>
 <p><b>Validez de las respuestas (escalas X, Y, Z, V):</b></p>
 <ul>
-<li>X Sinceridad: ${x.br} (${x.clas})</li>
-<li>Y Deseabilidad Social: ${y.br} (${y.clas})</li>
-<li>Z Devaluación: ${z.br} (${z.clas})</li>
-<li>V Validez: ${v.br} (${valido})</li>
+<li>X Sinceridad: Br ${x.bruto}, BR ${x.br} (${x.clas})</li>
+<li>Y Deseabilidad Social: Br ${y.bruto}, BR ${y.br} (${y.clas})</li>
+<li>Z Devaluación: Br ${z.bruto}, BR ${z.br} (${z.clas})</li>
+<li>V Validez: Br ${v.bruto}, BR ${v.br} (${valido})</li>
 </ul>
 <p><b>Estilo de respuesta:</b> </p>
 <h2>3 Severidad del Perfil Clínico</h2>


### PR DESCRIPTION
## Summary
- display raw score alongside BR when generating the Word report
- document that the downloadable report lists both raw and BR scores

## Testing
- `node --check main.js`
- `python3 -m py_compile sinceridad.py`

------
https://chatgpt.com/codex/tasks/task_e_68461f878c008328be4bdb0085ad9128