### PR TITLE
Update profile chart visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
         <div><span class="color invalido"></span> Inválido</div>
     </div>
     <h2>Perfil MCMI-III</h2>
-    <canvas id="mcmiChart" height="900"></canvas>
+    <canvas id="mcmiChart" class="hidden" width="1000" height="900"></canvas>
     <button id="descargar-informe">Descargar informe en Word</button>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -533,6 +533,7 @@ function actualizarGrafico() {
             }]
         },
         options: {
+            responsive: false,
             indexAxis: 'y',
             scales: {
                 x: { min: 0, max: 200, ticks: { stepSize: 10 }, grid: { drawTicks: true, drawOnChartArea: true } },
@@ -744,7 +745,6 @@ cuestionario.addEventListener('submit', function(event) {
         }
     });
 
-    actualizarGrafico();
     alert('Respuestas guardadas');
 });
 
@@ -753,6 +753,8 @@ function generarInforme() {
         alert("Primero completa y guarda el cuestionario");
         return;
     }
+    actualizarGrafico();
+    const chartImg = document.getElementById('mcmiChart').toDataURL('image/png');
     const nombre = datosPersonales.nombre || "";
     const edad = datosPersonales.edad || "";
     const sexo = datosPersonales.genero || "";
@@ -878,7 +880,7 @@ ${patronesHtml}
 <p><b>Relación entre los trastornos de personalidad (Eje II) y los síndromes clínicos (Eje I):</b> </p>
 <p><b>Análisis de cómo se influyen mutuamente:</b> </p>
 <p><b>Recomendaciones terapéuticas integrales:</b> </p>
-</body></html>`;
+<img src="${chartImg}" alt="Perfil MCMI-III"></body></html>`;
     const blob = new Blob(["\ufeff", html], { type: "application/msword" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/style.css
+++ b/style.css
@@ -3,6 +3,10 @@ body {
     margin: 20px;
 }
 
+.hidden {
+    display: none;
+}
+
 #datos-personales {
     max-width: 400px;
 }


### PR DESCRIPTION
## Summary
- hide profile chart on the page
- generate the chart only when exporting and embed at the end of the report
- ensure chart draws correctly when hidden

## Testing
- `python3 sinceridad.py 1 2 3 4 5 6 7 8 9 10 11`

------
https://chatgpt.com/codex/tasks/task_e_68462428928c83289b7b1a9b21c7da48