### PR TITLE
Adjust questionnaire UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,13 +30,11 @@
             <label><input type="radio" name="tiempo" value="sinenf" checked> Sin enfermedad</label>
         </fieldset>
         <br>
-        <button type="submit">Enviar</button>
     </form>
 
     <h2>Cuestionario</h2>
     <form id="cuestionario">
         <!-- Las preguntas se generan dinámicamente -->
-        <button type="submit">Guardar respuestas</button>
     </form>
 
     <h2>Resultados</h2>

--- a/main.js
+++ b/main.js
@@ -601,6 +601,12 @@ preguntas.forEach((texto, index) => {
     cuestionario.appendChild(fieldset);
 });
 
+const guardarBtn = document.createElement('button');
+guardarBtn.type = 'submit';
+guardarBtn.id = 'guardar-respuestas';
+guardarBtn.textContent = 'Guardar respuestas';
+cuestionario.appendChild(guardarBtn);
+
 cuestionario.addEventListener('submit', function(event) {
     event.preventDefault();
     const respuestas = {};

--- a/style.css
+++ b/style.css
@@ -31,6 +31,10 @@ button {
     padding: 5px 10px;
 }
 
+#guardar-respuestas {
+    background-color: #90EE90;
+}
+
 #resultados {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- remove the 'Enviar' submit button
- append the 'Guardar respuestas' button after the questions
- style the save button with a light green background

## Testing
- `python3 sinceridad.py 10 20 30 40 50 60 70 80 90 100 110`
- `python3 -m py_compile sinceridad.py`


------
https://chatgpt.com/codex/tasks/task_e_684627d947548328b9df66ad42d0bd61