### PR TITLE
Show MCMI chart on page only

### DIFF
--- a/main.js
+++ b/main.js
@@ -751,6 +751,12 @@ cuestionario.addEventListener('submit', function(event) {
         }
     });
 
+    const canvas = document.getElementById('mcmiChart');
+    if (canvas) {
+        canvas.classList.remove('hidden');
+        actualizarGrafico();
+    }
+
     alert('Respuestas guardadas');
 });
 


### PR DESCRIPTION
## Summary
- show the MCMI profile graph on the results page
- keep chart out of generated Word document

## Testing
- `python3 -m py_compile sinceridad.py`
- `node -e "require('fs').readFileSync('main.js');"`

------
https://chatgpt.com/codex/tasks/task_e_684636994a888328b1511e5d00a46690