### PR TITLE
Add evaluator info inputs and include in report

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Datos Personales</h1>
+    <h1>Datos Generales del Evaluado</h1>
     <p>Escriba los datos en los casilleros correspondientes</p>
     <form id="datos-personales">
         <label for="nombre">Nombre:</label>
@@ -30,6 +30,13 @@
             <label><input type="radio" name="tiempo" value="sinenf" checked> Sin enfermedad</label>
         </fieldset>
         <br>
+        <label for="fecha">Fecha de aplicación:</label>
+        <input type="date" id="fecha" name="fecha">
+        <br>
+        <label for="responsable">Responsable de la aplicación:</label>
+        <input type="text" id="responsable" name="responsable">
+        <br>
+        <button type="submit">Guardar datos</button>
     </form>
 
     <h2>Cuestionario</h2>

--- a/main.js
+++ b/main.js
@@ -2,6 +2,13 @@ let generoSeleccionado = 'F';
 let datosPersonales = {};
 let lastResults = null;
 let mcmiChart = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+    const fechaInput = document.getElementById('fecha');
+    if (fechaInput) {
+        fechaInput.value = new Date().toISOString().split('T')[0];
+    }
+});
 document.getElementById('datos-personales').addEventListener('submit', function(event) {
     event.preventDefault();
     const sel = document.querySelector('input[name="genero"]:checked');
@@ -12,7 +19,8 @@ document.getElementById('datos-personales').addEventListener('submit', function(
         nombre: document.getElementById("nombre").value,
         edad: document.getElementById("edad").value,
         genero: generoSeleccionado,
-        fecha: new Date().toLocaleDateString("es-ES")
+        fecha: document.getElementById("fecha").value || new Date().toLocaleDateString("es-ES"),
+        responsable: document.getElementById("responsable").value
     };
     Swal.fire({text: 'Formulario enviado', icon: 'success'});
 });
@@ -770,6 +778,7 @@ function generarInforme() {
     const edad = datosPersonales.edad || "";
     const sexo = datosPersonales.genero || "";
     const fecha = datosPersonales.fecha || "";
+    const responsable = datosPersonales.responsable || "";
     const baremo = sexo === "F" ? "Femenino" : (sexo === "M" ? "Masculino" : "");
 
     function infoBR(clave) {
@@ -856,7 +865,7 @@ function generarInforme() {
 <p><b>Sexo:</b> ${sexo}</p>
 <p><b>Fecha de aplicación:</b> ${fecha}</p>
 <p><b>Baremo utilizado:</b> ${baremo}</p>
-<p><b>Responsable de la aplicación:</b> </p>
+<p><b>Responsable de la aplicación:</b> ${responsable}</p>
 <h2>2 Actitud ante la prueba</h2>
 <p><b>Validez de las respuestas (escalas X, Y, Z, V):</b></p>
 <ul>


### PR DESCRIPTION
## Summary
- add name and other fields in the evaluator data form
- store date and responsible name when form is submitted
- inject evaluator data in generated report
- set default date to current day

## Testing
- `node --check main.js`
- `python3 -m py_compile sinceridad.py`


------
https://chatgpt.com/codex/tasks/task_e_6847278d6d5c8328b3a34bcfe9c00b09